### PR TITLE
Remove createServer method from server instantiation in example.

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -49,7 +49,7 @@ passport.use(new RedditStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
 app.configure(function() {


### PR DESCRIPTION
When running the app.js file in node I received the following error:

'... express.createServer() is deprecated, express applications no longer inherit from http.Server...'

So I changed line 52 in the app.js file in the login example from:

var app = express.createServer();

to:

var app = express();

Thanks :)
