### PR TITLE
Use passport-oauth2 state routines by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,34 +46,24 @@ application:
 
 ```javascript
 app.get('/auth/reddit', function(req, res, next){
-  req.session.state = crypto.randomBytes(32).toString('hex');
   passport.authenticate('reddit', {
-    state: req.session.state,
     duration: 'permanent',
   })(req, res, next);
 });
 
 app.get('/auth/reddit/callback', function(req, res, next){
-  // Check for origin via state token
-  if (req.query.state == req.session.state){
-    passport.authenticate('reddit', {
-      successRedirect: '/',
-      failureRedirect: '/login'
-    })(req, res, next);
-  }
-  else {
-    next( new Error(403) );
-  }
+  passport.authenticate('reddit', {
+    successRedirect: '/',
+    failureRedirect: '/login'
+  })(req, res, next);
 });
 ```
 
-##### `state` option use
-Reddit requires state, otherwise erring out.
-I've decided to opt out of providing default state, since it kills the whole purpose of the flag.
-If you don't want to use it, provide any string and don't check for it on user return.
+##### `duration` option on authenticate call
 
-Also included is the optional `duration` parameter, to request a slightly longer authorization.
-Defaults to `temporary` (1 hour).
+This strategy supports`duration` option on authenticate call, to request an indefinite authorization as opposed to 1 hour default.  
+Possible values: `permanent` and `temporary` (1 hour).
+
 Defined in the official [Reddit OAuth spec](https://github.com/reddit/reddit/wiki/OAuth2#authorization-parameters)
 
 ## Examples

--- a/examples/login/app.mjs
+++ b/examples/login/app.mjs
@@ -95,12 +95,8 @@ app.get('/login', function(req, res) {
 //   request.  The first step in Reddit authentication will involve
 //   redirecting the user to reddit.com.  After authorization, Reddit
 //   will redirect the user back to this application at /auth/reddit/callback
-//
-//   Note that the 'state' option is a Reddit-specific requirement.
 app.get('/auth/reddit', function(req, res, next) {
-  req.session.state = randomBytes(32).toString('hex')
   passport.authenticate('reddit', {
-    state: req.session.state,
     duration: 'permanent'
   })(req, res, next)
 })
@@ -111,16 +107,10 @@ app.get('/auth/reddit', function(req, res, next) {
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
 app.get('/auth/reddit/callback', function(req, res, next) {
-  // Check for origin via state token
-  if (req.query.state == req.session.state) {
-    passport.authenticate('reddit', {
-      successRedirect: '/',
-      failureRedirect: '/login'
-    })(req, res, next)
-  }
-  else {
-    next(new Error(403))
-  }
+  passport.authenticate('reddit', {
+    successRedirect: '/',
+    failureRedirect: '/login'
+  })(req, res, next)
 })
 
 app.get('/logout', function(req, res) {

--- a/lib/passport-reddit/strategy.js
+++ b/lib/passport-reddit/strategy.js
@@ -70,6 +70,9 @@ class Strategy extends OAuth2Strategy {
       options.scope = 'identity'
     }
 
+    // Enable state handling by default, but ~~allow foot shooting~~ future-proof by allowing a false value
+    if (typeof options.state === 'undefined' && typeof options.store === 'undefined') { options.state = true }
+
     super(options, verify)
     this._userProfileURL = options.userProfileURL || this._defaultUserProfileURL
     // Reddit requires Auth token in GET requests


### PR DESCRIPTION
Unless state or store options are provided,
set state option to true to let passport-oauth2
routines to handle state checking.

State mismatch is then handled as a failure and
yields `failureRedirect`.