### PR TITLE
Bump version to 1.1.0 and prepare for publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,9 @@
 README.md
-Makefile
 doc/
 examples/
 test/
 coverage/
+.eslintrc.json
 
 # Mac OS X
 .DS_Store
@@ -16,4 +16,5 @@ npm-debug.log
 # Git
 .git*
 
-.coveralls.yml
+# CI
+.travis.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-reddit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Reddit authentication strategy for Passport.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Default state handling is highly unlikely to
clash in existing deploys, but there's still
a chance and so it should be mentioned as
a new feature with potential for conflict.

Also clean up .npmignore a bit